### PR TITLE
Use Bazel mirror to download externals

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Damien Martin-Guillerez <dmarting@google.com>
 David Chen <dzc@google.com>
 Erik Kuefler <ekuefler@gmail.com>
 Kristina Chodorow <kchodorow@google.com>
+Justine Alexandra Roberts Tunney <jart@google.com>

--- a/groovy/groovy.bzl
+++ b/groovy/groovy.bzl
@@ -378,7 +378,7 @@ def spock_test(
 def groovy_repositories():
   native.new_http_archive(
     name = "groovy_sdk_artifact",
-    url = "http://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.4.zip",
+    url = "http://bazel-mirror.storage.googleapis.com/dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.4.zip",
     sha256 = "a7cc1e5315a14ea38db1b2b9ce0792e35174161141a6a3e2ef49b7b2788c258c",
     build_file_content = """
 filegroup(
@@ -402,9 +402,15 @@ java_import(
     actual = "@groovy_sdk_artifact//:groovy",
   )
 
+  native.maven_server(
+    name = "groovy_maven_server",
+    url = "http://bazel-mirror.storage.googleapis.com/repo1.maven.org/maven2/",
+  )
+
   native.maven_jar(
     name = "junit_artifact",
     artifact = "junit:junit:4.12",
+    server = "groovy_maven_server",
   )
   native.bind(
     name = "junit",
@@ -414,6 +420,7 @@ java_import(
   native.maven_jar(
     name = "spock_artifact",
     artifact = "org.spockframework:spock-core:0.7-groovy-2.0",
+    server = "groovy_maven_server",
   )
   native.bind(
     name = "spock",


### PR DESCRIPTION
I've mirrored your files for guaranteed reliability, courtesy of Google Cloud Storage.

In the future, you can mirror these files too with the following command. Although you need to ask @damienmg for write access to the bucket. Or just email me the URL you want mirrored and I'll happily do it.

```bash
bzmirror() {
  local url="${1:?url}"
  if [[ "${url}" =~ ^([^:]+):([^:]+):([^:]+)$ ]]; then
    url="http://repo1.maven.org/maven2/${BASH_REMATCH[1]//.//}/${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.jar"
  fi
  local dest="gs://bazel-mirror/${url#http*//}"
  local desturl="http://bazel-mirror.storage.googleapis.com/${url#http*//}"
  local name="$(basename "${dest}")"
  wget -O "/tmp/${name}" "${url}" || return 1
  gsutil cp -a public-read "/tmp/${name}" "${dest}" || return 1
  gsutil setmeta -h 'Cache-Control:public, max-age=31536000' "${dest}" || return 1
  curl -I "${desturl}"
  echo
  sha256sum "/tmp/${name}"
  echo "${desturl}"
  rm "/tmp/${name}" || return 1
}
```