### PR TITLE
Remove exclude_directories=0 from the sdk filegroup.

### DIFF
--- a/groovy/groovy.bzl
+++ b/groovy/groovy.bzl
@@ -385,7 +385,7 @@ def groovy_repositories():
     build_file_content = """
 filegroup(
     name = "sdk",
-    srcs = glob(["groovy-2.4.4/**"], exclude_directories=0),
+    srcs = glob(["groovy-2.4.4/**"]),
     visibility = ["//visibility:public"],
 )
 java_import(


### PR DESCRIPTION
This fixes an issue where the groovy rules don't work with sandboxing enabled.

Without this patch:
```
philwo@philwo:~/src/continuous-integration ((2cafa90...))$ bazel build //jenkins/lib:BazelConfigurationParsingTest-impl
ERROR: /usr/local/google/home/philwo/src/continuous-integration/jenkins/lib/BUILD:24:1: error executing shell command: 'set -e;rm -rf bazel-out/local-fastbuild/bin/jenkins/lib/libBazelConfigurationParsingTest-impl.jar.build_output
mkdir -p bazel-out/local-fastbuild/bin/jenkins/lib/libBazelConfigurationParsingTest-im...' failed: I/O exception during sandboxed execution: /usr/local/google/home/philwo/.cache/bazel/_bazel_but_philwo/ddee209bbd16f4cd567eafdd22f44631/bazel-sandbox/3821159014396435374/execroot/continuous-integration/external/groovy_sdk_artifact/groovy-2.4.4 (Directory not empty)
Target //jenkins/lib:BazelConfigurationParsingTest-impl failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 86.464s, Critical Path: 83.80s
FAILED: Build did NOT complete successfully
```

With this patch:
```
philwo@philwo:~/src/continuous-integration ((2cafa90...))$ bazel build //jenkins/lib:BazelConfigurationParsingTest-impl
Target //jenkins/lib:BazelConfigurationParsingTest-impl up-to-date:
  bazel-bin/jenkins/lib/libBazelConfigurationParsingTest-impl.jar
INFO: Elapsed time: 4.467s, Critical Path: 0.62s
INFO: Build completed successfully, 2 total actions
```
