### PR TITLE
Mark generated child rules of spock_test and groovy_junit_test testonly

### DIFF
--- a/groovy/groovy.bzl
+++ b/groovy/groovy.bzl
@@ -109,7 +109,7 @@ _groovy_jar = rule(
     implementation = _groovy_jar_impl,
 )
 
-def groovy_library(name, srcs=[], deps=[], testonly=0, **kwargs):
+def groovy_library(name, srcs=[], testonly=0, deps=[], **kwargs):
   """Rule analagous to java_library that accepts .groovy sources instead of
   .java sources. The result is wrapped in a java_import so that java rules may
   depend on it.
@@ -117,8 +117,8 @@ def groovy_library(name, srcs=[], deps=[], testonly=0, **kwargs):
   _groovy_jar(
       name = name + "-impl",
       srcs = srcs,
-      deps = deps,
       testonly = testonly,
+      deps = deps,
   )
   native.java_import(
       name = name,

--- a/groovy/groovy.bzl
+++ b/groovy/groovy.bzl
@@ -109,7 +109,7 @@ _groovy_jar = rule(
     implementation = _groovy_jar_impl,
 )
 
-def groovy_library(name, srcs=[], deps=[], **kwargs):
+def groovy_library(name, srcs=[], deps=[], testonly=0, **kwargs):
   """Rule analagous to java_library that accepts .groovy sources instead of
   .java sources. The result is wrapped in a java_import so that java rules may
   depend on it.
@@ -118,10 +118,12 @@ def groovy_library(name, srcs=[], deps=[], **kwargs):
       name = name + "-impl",
       srcs = srcs,
       deps = deps,
+      testonly = testonly,
   )
   native.java_import(
       name = name,
       jars = [name + "-impl"],
+      testonly = testonly,
       deps = deps,
       **kwargs
   )
@@ -261,6 +263,7 @@ def groovy_test(
     native.java_library(
       name = name + "-resources",
       resources = resources,
+      testonly = 1,
     )
     all_deps += [name + "-resources"]
 
@@ -296,6 +299,7 @@ def groovy_junit_test(
     native.java_library(
       name = name + "-javalib",
       srcs = java_srcs,
+      testonly = 1,
       deps = deps + ["//external:junit"],
     )
     groovy_lib_deps += [name + "-javalib"]
@@ -305,6 +309,7 @@ def groovy_junit_test(
   groovy_library(
     name = name + "-groovylib",
     srcs = tests + groovy_srcs,
+    testonly = 1,
     deps = groovy_lib_deps,
   )
   test_deps += [name + "-groovylib"]
@@ -349,6 +354,7 @@ def spock_test(
     native.java_library(
       name = name + "-javalib",
       srcs = java_srcs,
+      testonly = 1,
       deps = deps + [
         "//external:junit",
         "//external:spock",
@@ -361,6 +367,7 @@ def spock_test(
   groovy_library(
     name = name + "-groovylib",
     srcs = specs + groovy_srcs,
+    testonly = 1,
     deps = groovy_lib_deps,
   )
   test_deps += [name + "-groovylib"]


### PR DESCRIPTION
Currently the auto-generated child rules of spock_test and groovy_junit_test are not marked as testonly, which means they can't depend on other testonly packages.