### PR TITLE
Add config to run CI on remote execution

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,6 +6,9 @@ platforms:
   ubuntu1604:
     build_targets:
     - "..."
+  rbe_ubuntu1604:
+    build_targets:
+    - "..."
   macos:
     build_targets:
     - "..."

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,14 @@
 workspace(name = "io_bazel_rules_groovy")
 
+http_archive(
+  name = "bazel_toolchains",
+  urls = [
+    "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/cdea5b8675914d0a354d89f108de5d28e54e0edc.tar.gz",
+    "https://github.com/bazelbuild/bazel-toolchains/archive/cdea5b8675914d0a354d89f108de5d28e54e0edc.tar.gz",
+  ],
+  strip_prefix = "bazel-toolchains-cdea5b8675914d0a354d89f108de5d28e54e0edc",
+  sha256 = "cefb6ccf86ca592baaa029bcef04148593c0efe8f734542f10293ea58f170715",
+)
+
 load("//groovy:groovy.bzl", "groovy_repositories")
 groovy_repositories()


### PR DESCRIPTION
Also add bazel-toolchain repo that provides toolchain configurations needed for use with rbe-ubuntu16-04 CI config
