### PR TITLE
#25: get all tests passing with --all_incompatible_changes under Bazel 0.20.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /bazel-*
+
+# Ignore IntelliJ library files
+.ijwb

--- a/example/src/main/groovy/app/BUILD
+++ b/example/src/main/groovy/app/BUILD
@@ -1,10 +1,10 @@
 load("@io_bazel_rules_groovy//groovy:groovy.bzl", "groovy_binary")
 
 groovy_binary(
-  name = "GroovyApp",
-  srcs = glob(["*.groovy"]),
-  main_class = "app.GroovyApp",
-  deps = [
-    "//example/src/main/groovy/lib:groovylib",
-  ],
+    name = "GroovyApp",
+    srcs = glob(["*.groovy"]),
+    main_class = "app.GroovyApp",
+    deps = [
+        "//example/src/main/groovy/lib:groovylib",
+    ],
 )

--- a/example/src/main/groovy/lib/BUILD
+++ b/example/src/main/groovy/lib/BUILD
@@ -5,7 +5,7 @@ groovy_library(
     srcs = glob(["*.groovy"]),
     visibility = ["//visibility:public"],
     deps = [
-      ":javalib",
+        ":javalib",
     ],
 )
 


### PR DESCRIPTION
- Format all files with buildifier.
- Run buildifier --lint=fix.
- Move `_zipper` to `tools` to fix `--incompatible_no_support_tools_in_action_inputs`.
- Avoid a depset union to fix `--incompatible_depset_union`.