### PR TITLE
Prepare for --incompatible_load_java_rules_from_bzl

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ targets:
 
 The easiest way to do so is to add the following to your `WORKSPACE` file:
 
+<!---
+    Replace snippet w/ following after next tagged release:
+
+load("@io_bazel_rules_groovy//groovy:repositories.bzl", "rules_groovy_dependencies")
+rules_groovy_dependencies()
+-->
 ```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,8 +7,8 @@ http_archive(
     sha256 = "5962fe677a43226c409316fcb321d668fc4b7fa97cb1f9ef45e7dc2676097b26",
     strip_prefix = "bazel-toolchains-be10bee3010494721f08a0fccd7f57411a1e773e",
     urls = [
-      "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/be10bee3010494721f08a0fccd7f57411a1e773e.tar.gz",
-      "https://github.com/bazelbuild/bazel-toolchains/archive/be10bee3010494721f08a0fccd7f57411a1e773e.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/be10bee3010494721f08a0fccd7f57411a1e773e.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/be10bee3010494721f08a0fccd7f57411a1e773e.tar.gz",
     ],
 )
 
@@ -20,5 +20,6 @@ rbe_autoconfig(
     name = "buildkite_config",
 )
 
-load("//groovy:groovy.bzl", "groovy_repositories")
-groovy_repositories()
+load("//groovy:repositories.bzl", "rules_groovy_dependencies")
+
+rules_groovy_dependencies()

--- a/groovy/repositories.bzl
+++ b/groovy/repositories.bzl
@@ -1,0 +1,79 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def rules_groovy_dependencies():
+    maybe(
+        http_archive,
+        name = "rules_java",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/rules_java-0.1.1.tar.gz",
+            "https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz",
+        ],
+        sha256 = "220b87d8cfabd22d1c6d8e3cdb4249abd4c93dcc152e0667db061fb1b957ee68",
+    )
+
+    http_archive(
+        name = "groovy_sdk_artifact",
+        urls = [
+            "https://mirror.bazel.build/dl.bintray.com/groovy/maven/apache-groovy-binary-2.5.8.zip",
+            "https://dl.bintray.com/groovy/maven/apache-groovy-binary-2.5.8.zip",
+        ],
+        sha256 = "49fb14b98f9fed1744781e4383cf8bff76440032f58eb5fabdc9e67a5daa8742",
+        build_file_content = """
+filegroup(
+    name = "sdk",
+    srcs = glob(["groovy-2.5.8/**"]),
+    visibility = ["//visibility:public"],
+)
+java_import(
+    name = "groovy",
+    jars = ["groovy-2.5.8/lib/groovy-2.5.8.jar"],
+    visibility = ["//visibility:public"],
+)
+""",
+    )
+    native.bind(
+        name = "groovy-sdk",
+        actual = "@groovy_sdk_artifact//:sdk",
+    )
+    native.bind(
+        name = "groovy",
+        actual = "@groovy_sdk_artifact//:groovy",
+    )
+
+    jvm_maven_import_external(
+        name = "junit_artifact",
+        artifact = "junit:junit:4.12",
+        server_urls = ["https://mirror.bazel.build/repo1.maven.org/maven2"],
+        licenses = ["notice"],
+    )
+    native.bind(
+        name = "junit",
+        actual = "@junit_artifact//jar",
+    )
+
+    jvm_maven_import_external(
+        name = "spock_artifact",
+        artifact = "org.spockframework:spock-core:1.3-groovy-2.5",
+        server_urls = ["https://mirror.bazel.build/repo1.maven.org/maven2"],
+        licenses = ["notice"],
+    )
+    native.bind(
+        name = "spock",
+        actual = "@spock_artifact//jar",
+    )


### PR DESCRIPTION
- groovy.bzl: Load Java rules from rules_java.
- repositories.bzl: Follow example from
  https://docs.bazel.build/versions/master/skylark/deploying.html#dependencies.

RELNOTES: Dependencies macro `groovy_repositories` moved
    to @io_bazel_rules_groovy//groovy:repositories.bzl
    and renamed to `rules_groovy_dependencies` per
    https://docs.bazel.build/versions/master/skylark/deploying.html#dependencies.

Resolves #44.