### PR TITLE
Update bazel-toolchains to 3.1.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "5962fe677a43226c409316fcb321d668fc4b7fa97cb1f9ef45e7dc2676097b26",
-    strip_prefix = "bazel-toolchains-be10bee3010494721f08a0fccd7f57411a1e773e",
+    sha256 = "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
+    strip_prefix = "bazel-toolchains-3.1.0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/be10bee3010494721f08a0fccd7f57411a1e773e.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/be10bee3010494721f08a0fccd7f57411a1e773e.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
The version of bazel-toolchain in the current WORKSPACE file has some invalid escape sequences (https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1756#c72e7bb7-2aae-49e5-ad26-a2216975d589). Bazel itself uses bazel-toolchains 3.1.0 right now, and those invalid escape sequences have been fixed some time before 3.1.0.