### PR TITLE
unhardcode java location

### DIFF
--- a/groovy/groovy.bzl
+++ b/groovy/groovy.bzl
@@ -225,7 +225,7 @@ def _groovy_test_impl(ctx):
     classes = [path_to_class(src.path) for src in ctx.files.srcs]
 
     # Write a file that executes JUnit on the inferred classes
-    cmd = "external/local_jdk/bin/java %s -cp %s org.junit.runner.JUnitCore %s\n" % (
+    cmd = "$JAVA_HOME/bin/java %s -cp %s org.junit.runner.JUnitCore %s\n" % (
         " ".join(ctx.attr.jvm_flags),
         ":".join([dep.short_path for dep in all_deps.to_list()]),
         " ".join(classes),


### PR DESCRIPTION
This PR unhardcodes the Java location for test targets, favoring `$JAVA_HOME` instead.