### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,14 +1,11 @@
 ---
 platforms:
-  ubuntu1604:
-    build_targets:
-    - "..."
   ubuntu1804:
     build_targets:
-    - "..."
+    - "//..."
   rbe_ubuntu1604:
     build_targets:
-    - "..."
+    - "//..."
   macos:
     build_targets:
-    - "..."
+    - "//..."


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.