### PR TITLE
Migrate usages of deprecated `JavaInfo` fields

### DIFF
--- a/groovy/groovy.bzl
+++ b/groovy/groovy.bzl
@@ -26,7 +26,7 @@ def _groovy_jar_impl(ctx):
     all_deps = depset(
         ctx.files.deps,
         transitive = [
-            dep[JavaInfo].transitive_runtime_deps
+            dep[JavaInfo].transitive_runtime_jars
             for dep in ctx.attr.deps
             if JavaInfo in dep
         ],
@@ -215,7 +215,7 @@ def _groovy_test_impl(ctx):
     all_deps = depset(
         ctx.files.deps + ctx.files._implicit_deps + groovy_sdk_jars,
         transitive = [
-            dep[JavaInfo].transitive_runtime_deps
+            dep[JavaInfo].transitive_runtime_jars
             for dep in ctx.attr.deps
             if JavaInfo in dep
         ],


### PR DESCRIPTION
 - `transitive_deps` was an alias for `transitive_compile_time_jars` 
- `transitive_runtime_deps` was an alias for `transitive_runtime_jars`

The fields were deprecated in 2021, and are dropped in Bazel@HEAD

Fixes https://github.com/bazelbuild/rules_groovy/issues/66